### PR TITLE
Reapply Danny's patch

### DIFF
--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -1939,6 +1939,104 @@ setXFilesFactor.params = [
 ]
 
 
+def resample(requestContext, seriesList, pointsPerPx = 1):
+  """
+  Resamples the given series according to the requested graph width and
+  $pointsPerPx aggregating by average. Total number of points after this
+  function == graph width * pointsPerPx.
+  This has two significant uses:
+   * Drastically speeds up render time when graphing high resolution data
+     or many metrics.
+   * Allows movingAverage() to have a consistent smoothness across timescales.
+     * Example:  movingAverage(resample(metric,2),20) would end up with
+       a 10px moving average no matter what the scale of your graph.
+   * Allows a consistent number-of-samples to be returned from JSON requests
+     * the number of samples returned == graph width * points per pixel
+  Example:
+  .. code-block:: none
+    &target=resample(metric, 2)
+    &target=movingAverage(resample(metric, 2), 20)
+  """
+  newSampleCount = requestContext['width']
+
+  for seriesIndex, series in enumerate(seriesList):
+    newValues = []
+    seriesLength = (series.end - series.start)
+    newStep = (float(seriesLength) / float(newSampleCount)) / float(pointsPerPx)
+
+    # Leave this series alone if we're asked to do upsampling
+    if newStep < series.step:
+      continue
+
+    sampleWidth = 0
+    sampleCount = 0
+    sampleSum = 0
+
+    for value in series:
+      if (value is not None):
+        sampleCount += 1
+        sampleSum += value
+      sampleWidth += series.step
+
+      # If the current sample covers the width of a new step, add it to the
+      # result
+      if (sampleWidth >= newStep):
+        if sampleCount > 0:
+          newValues.append(sampleSum / sampleCount)
+        else:
+          newValues.append(None)
+        sampleWidth -= newStep
+        sampleSum = 0
+        sampleCount = 0
+
+    # Process and add the left-over sample if it's not empty
+    if sampleCount > 0:
+      newValues.append(sampleSum / sampleCount)
+
+    newName = "resample(%s, %s)" % (series.name, pointsPerPx)
+    newSeries = TimeSeries(newName, series.start, series.end, newStep, newValues)
+    newSeries.pathExpression = newName
+    seriesList[seriesIndex] = newSeries
+
+  return seriesList
+
+
+def smooth(requestContext, seriesList, windowPixelSize = 5):
+  """
+  Resample and smooth a set of metrics. Provides line smoothing that is
+  independent of time scale (windowPixelSize ~ movingAverage over pixels)
+  An shorter and safer way of calling:
+     movingAverage(resample(seriesList, 2), smoothFactor * 2)
+  The windowPixelSize is effectively the number of pixels over which to perform
+  the movingAverage.
+  Note: This is safer in that if a series has fewer data points than pixels,
+  the metric won't be upsampled.  Instead the movingAverage window size will be
+  adjusted to cover the same number of pixels.
+  """
+  pointsPerPixel = 2
+  resampled = resample(requestContext, seriesList, pointsPerPixel)
+
+  sampleSize = int(windowPixelSize * pointsPerPixel)
+  expectedSamples = requestContext['width'] * pointsPerPixel
+
+  for index, series in enumerate(resampled):
+    # if we have fewer samples than expected, adjust the movingAverage sample
+    # size so it covers the same number of pixels
+    if (len(series) < expectedSamples * 0.95):
+      movingAverageSize = int((float(len(series)) / (expectedSamples)) * sampleSize)
+    else:
+      movingAverageSize = sampleSize
+
+    # If we are being asked to do a movingAverage over one point or less,
+    # don't bother
+    if (movingAverageSize <= 1):
+      continue
+
+    resampled[index] = movingAverage(requestContext, [series], movingAverageSize)[0]
+
+  return resampled
+
+
 def derivative(requestContext, seriesList):
   """
   This is the opposite of the integral function.  This is useful for taking a

--- a/webapp/graphite/render/functions.py
+++ b/webapp/graphite/render/functions.py
@@ -5821,6 +5821,8 @@ SeriesFunctions = {
   'timeSlice': timeSlice,
   'timeStack': timeStack,
   'transformNull': transformNull,
+  'resample'  : resample,
+  'smooth' : smooth,
 
   # Calculate functions
   'aggregateLine': aggregateLine,

--- a/webapp/graphite/render/views.py
+++ b/webapp/graphite/render/views.py
@@ -65,6 +65,8 @@ def renderView(request):
     'endTime' : requestOptions['endTime'],
     'now': requestOptions['now'],
     'localOnly' : requestOptions['localOnly'],
+    'width' : graphOptions['width'],
+    'height' : graphOptions['height'],
     'template' : requestOptions['template'],
     'tzinfo' : requestOptions['tzinfo'],
     'forwardHeaders': requestOptions['forwardHeaders'],


### PR DESCRIPTION
@danielbeardsley gave us this diff to glean the delta on our fork to `ifixit-production`:
https://github.com/graphite-project/graphite-web/compare/0.9.x...iFixit:ifixit-production#

The patch is relatively simple. Add two new transform functions, wire them into the render functions dictionary, and little retouch the request context to also include some graph options.

This seems to work a treat!

@danielbeardsley, please feel free to rebase this branch for the authorship credit, if you so wish.

We skipped adding the two new functions to the widgets, as we expect graphite to be mostly read-only now. Maybe we should though...

qa_req 0 (this is at least 99% working)

Ref: https://github.com/iFixit/server-templates/issues/2748
Ref: https://github.com/iFixit/server-templates/issues/2733
Ref: https://github.com/iFixit/server-templates/issues/2583

CC @andyg0808 @danielbeardsley 